### PR TITLE
Added simple function prop to obtain formatted time

### DIFF
--- a/src/Time.svelte
+++ b/src/Time.svelte
@@ -15,6 +15,7 @@
   const setTime = throttle(
     () => {
       ft = formatTime(currentTime, hours);
+      getTime && getTime(ft);
     },
     250,
     true

--- a/src/VideoPlayer.svelte
+++ b/src/VideoPlayer.svelte
@@ -28,6 +28,7 @@
   export let skipSeconds = 5;
   export let controlsOnPause = true;
   export let timeDisplay = false;
+  export let getTime = false;
 
   $: _width = parseInt(width);
   $: _height = parseInt(height);
@@ -56,7 +57,8 @@
     {skipSeconds}
     {aspectRatio}
     {controlsOnPause}
-    {timeDisplay} />
+    {timeDisplay}
+    {getTime} />
 {:else}
   <VideoPlayerServer {playerBgColor} {borderRadius} {aspectRatio} />
 {/if}

--- a/src/VideoPlayerClient.svelte
+++ b/src/VideoPlayerClient.svelte
@@ -52,6 +52,7 @@
   export let aspectRatio;
   export let controlsOnPause;
   export let timeDisplay;
+  export let getTime;
 
   $: _sources = prepareVideoSources(source);
   $: _skipSeconds = parseFloat(skipSeconds);
@@ -328,7 +329,7 @@
             bind:isScrubbing
             on:pointerup={onPlaybarPointerUp} />
           {#if timeDisplay}
-            <Time {duration} {currentTime} />
+            <Time {getTime} {duration} {currentTime} />
           {/if}
           <VolumeButton on:pointerup={onVolumeButtonPointerUp} {muted} />
           <VolumeControl bind:volume />


### PR DESCRIPTION
Allows formatted time from the video player to be returned when _**setTime**_ is executed; useful for displaying messages or changing content on a page depending on the video's current timestamp.

### Example usage

```javascript
let getTime = (time) => console.log(time);
```

### Example result

![image](https://user-images.githubusercontent.com/54673205/137224908-a78df611-28b6-4ee8-a7c4-e6cd759eeb9c.png)

