### PR TITLE
:bug:  Make player icon transitions local

### DIFF
--- a/src/PlayIconCenter.svelte
+++ b/src/PlayIconCenter.svelte
@@ -24,7 +24,7 @@
   <div
     class="player-icon"
     style="background-color:{$cfg.color}; border-color:{$cfg.focusColor};"
-    transition:fade={{ duration: 500 }}>
+    transition:fade|local={{ duration: 500 }}>
     <PlayPauseIcon paused />
   </div>
 {/if}


### PR DESCRIPTION
# Description
 - The player icon transition effects only play when the immediate parent block is added or removed.

## Type of change
- [x] 🐛 bug fix

## Verified on

- [x] Google Chrome
